### PR TITLE
update solidjs router (but seems bugged)

### DIFF
--- a/applications/sandbox/entry.tsx
+++ b/applications/sandbox/entry.tsx
@@ -12,7 +12,7 @@ import '../../packages/styles/variables-custom.css';
 import './variables.css';
 import '../../packages/styles/keyframes.css';
 import '../../packages/styles/normalize.css';
-import { Route, Navigate, Router, Routes } from '@solidjs/router';
+import { Route, Navigate, Router } from '@solidjs/router';
 import { createEffect, For, Suspense } from 'solid-js';
 import { render } from 'solid-js/web';
 
@@ -43,16 +43,14 @@ const ApplicationWrapper = () => {
     <Router>
       <ApplicationFrame isLoading={dynamicRoutes.isLoading()} navigation={dynamicRoutes.navigation()}>
         <Suspense fallback={<Loading />}>
-          <Routes>
-            {/* these are the dynamic routes that are based on the files dynamically loaded with sandbox components */}
-            <For each={dynamicRoutes.routes()}>
-              {(route) => {
-                return <Route path={route.path} component={route.component} />;
-              }}
-            </For>
-            <Route path="/" component={HomeView} />
-            <Route path="*" component={() => <Navigate href="/" />} />
-          </Routes>
+          {/* these are the dynamic routes that are based on the files dynamically loaded with sandbox components */}
+          <For each={dynamicRoutes.routes()}>
+            {(route) => {
+              return <Route path={route.path} component={route.component} />;
+            }}
+          </For>
+          <Route path="/" component={HomeView} />
+          <Route path="*" component={() => <Navigate href="/" />} />
         </Suspense>
       </ApplicationFrame>
       <GlobalNotificationsList notifications={globalNotificationsStore.notifications()} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/inter": "5.0.16",
         "@fontsource/roboto": "5.0.8",
         "@solid-primitives/scheduled": "1.4.1",
-        "@solidjs/router": "0.9.0",
+        "@solidjs/router": "0.10.3",
         "@thisbeyond/solid-dnd": "0.7.5",
         "classnames": "2.3.2",
         "date-fns": "2.30.0",
@@ -1925,11 +1925,11 @@
       }
     },
     "node_modules/@solidjs/router": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solidjs/router/-/router-0.9.0.tgz",
-      "integrity": "sha512-q1RxUhLa8lKdbhqEPkG+8RwBQKIH5f5AIWiOxVoUTK4UllgsR0C0FNT++ufnIAb9LNkx3ahE4WxAHZqH4l1vEQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@solidjs/router/-/router-0.10.3.tgz",
+      "integrity": "sha512-UZyUcGbMzeJWCJZthWfveFbv9FyMLi62+BHpXyVwAYpowHaUkkV3WVKoYxYF9m47fVG23UfUo2S6GbuyPAyCjw==",
       "peerDependencies": {
-        "solid-js": "^1.5.3"
+        "solid-js": "^1.8.6"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -13858,9 +13858,9 @@
       "requires": {}
     },
     "@solidjs/router": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solidjs/router/-/router-0.9.0.tgz",
-      "integrity": "sha512-q1RxUhLa8lKdbhqEPkG+8RwBQKIH5f5AIWiOxVoUTK4UllgsR0C0FNT++ufnIAb9LNkx3ahE4WxAHZqH4l1vEQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@solidjs/router/-/router-0.10.3.tgz",
+      "integrity": "sha512-UZyUcGbMzeJWCJZthWfveFbv9FyMLi62+BHpXyVwAYpowHaUkkV3WVKoYxYF9m47fVG23UfUo2S6GbuyPAyCjw==",
       "requires": {}
     },
     "@szmarczak/http-timer": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@fontsource/inter": "5.0.16",
     "@fontsource/roboto": "5.0.8",
     "@solid-primitives/scheduled": "1.4.1",
-    "@solidjs/router": "0.9.0",
+    "@solidjs/router": "0.10.3",
     "@thisbeyond/solid-dnd": "0.7.5",
     "classnames": "2.3.2",
     "date-fns": "2.30.0",


### PR DESCRIPTION
Maybe I am doing something wrong but it seems like solidjs router is bugged when I upgrade to `0.10.x`. I looked at the migration notes here : https://github.com/solidjs/solid-router#migrations-from-09x : and I removed the use of `<Routes />` but it just complete breaks (nothing loads).

The error I get is:
![Screen Shot 2023-12-16 at 1 51 48 PM](https://github.com/ryanzec/train-ui/assets/444206/f635b797-a294-406c-bb5d-8a75d17e4879)

Which references this line:
https://github.com/ryanzec/train-ui/blob/419da7730acd83cd2dafdfdca53c256282293502/applications/sandbox/packages/components/application-frame/application-frame-navigation-item.tsx#L14

But it is in a `<Router />` so I am just not sure if there is some other thing I need to do in this migration.